### PR TITLE
Change the way of the key input

### DIFF
--- a/MZ-700/index.css
+++ b/MZ-700/index.css
@@ -27,6 +27,22 @@
     color: blue;
 }
 
+.MZ-700 .ctrl-panel > button.key-switcher,
+.MZ-700 .ctrl-panel > button.key-switcher:focus {
+    background-color: blue;
+    color: white;
+}
+.MZ-700 .ctrl-panel > button.key-switcher:hover {
+    background-color: white;
+    color: blue;
+}
+.MZ-700 .ctrl-panel > button.key-switcher.on,
+.MZ-700 .ctrl-panel > button.key-switcher.on:focus,
+.MZ-700 .ctrl-panel > button.key-switcher.on:hover {
+    background-color: white;
+    color: blue;
+}
+
 /**
  * アセンブルリスト
  */


### PR DESCRIPTION
To be simple.

Previously, the key events such as 'keydown' and 'keyup' were listened by a button object which has a focus. So, Whether the MZ-700 emulator processes the events is depend on which object has a focus.

This time, it is changed to receive the events by window object, and whether the events will be handled by the emulator is depend on the internal flag in the MZ-700 object.

If the screen area of the emulator is clicked, the events will be handled by the emulator. Otherwise, those will be handled by the browsers.