### PR TITLE
Fix the initial UI-states that depends on the mouse position

### DIFF
--- a/MZ-700/client.js
+++ b/MZ-700/client.js
@@ -140,6 +140,7 @@ if (ua.indexOf('iPhone') >= 0 || ua.indexOf('iPod') >= 0 ||
                 mouseMoveTimeoutId = null;
             }, timeLimit);
         };
+        showCtrlPanelFor(5000);
         screen.mousemove(function() {
             showCtrlPanelFor(5000);
         });

--- a/MZ-700/index.js
+++ b/MZ-700/index.js
@@ -40,7 +40,7 @@
         };
         this.isRunning = false;
         this.mz700scrn = null;
-        this.keyAcceptanceState = true;
+        this.keyAcceptanceState = false;
         this.keystates = {};
     };
     MZ700Js.create = function(opt) {


### PR DESCRIPTION
If the mouse pointer was not over the screen at start up and until
the pointer enters to the screen, the keyboard input would not be off
and the control panel will not disappear.