### PR TITLE
Revive the bottom border of the dump list header

### DIFF
--- a/lib/jquery.Z80-mem.css
+++ b/lib/jquery.Z80-mem.css
@@ -3,6 +3,7 @@
     font-size: 8pt;
     border-bottom: solid 1px gray;
     width: 100%;
+    height: 275px;
 }
 .dumplist .vscrlist {
     height: 293px;
@@ -16,11 +17,11 @@
     height: 16px;
     line-height:16px;
 }
-.dumplist > .row.header {
+.dumplist .row.header {
     border-bottom: solid 1px gray;
 }
-.dumplist > .row.header > .char-selector > label,
-.dumplist > .row.header > .char-selector > span
+.dumplist .row.header > .char-selector > label,
+.dumplist .row.header > .char-selector > span
 {
     vertical-align: top;
 }

--- a/lib/jquery.vscrlist.js
+++ b/lib/jquery.vscrlist.js
@@ -74,7 +74,7 @@ vscrlist.prototype.create = function(opt) {
 
     this._scroller.addClass("vscrlist")
         .addClass("scroller")
-        .css("height", "100%")
+        .css("height", "calc(100% - 22px)")
         .css("overflow", "auto")
         .append(this._scroll);
 


### PR DESCRIPTION
The CSS was not following the previous changes.
This commit is going to close the issue #84.