### PR TITLE
Handle scroll event to update the top-left address

### DIFF
--- a/lib/jquery.Z80-mem.js
+++ b/lib/jquery.Z80-mem.js
@@ -195,7 +195,11 @@ dumplist.prototype.init = function(opt) {
             }
             return $row.get(0);
         }
-    }).vscrlist("items", listItems);
+    }).vscrlist("items", listItems)
+    .on("scroll", () => {
+        let topItemIndex = this._hexdump.vscrlist("listTopIndex");
+        this._topLeftAddr = listItems[topItemIndex].startAddr;
+    });
     $container.append(this._hexdump);
     this._hexdump.append(this._hexadumpRows).css("height", "280px");
 

--- a/lib/jquery.vscrlist.js
+++ b/lib/jquery.vscrlist.js
@@ -96,6 +96,7 @@ vscrlist.prototype.create = function(opt) {
                 Math.round(scroller.scrollTop / this._opt.rowHeight);
             if(nextIndex != this._top_row_index) {
                 this._listTopIndex(nextIndex);
+                $(this._element).trigger("scroll");
                 this.createList();
             }
         }, 10);


### PR DESCRIPTION
The dump list could not update its top left address when the list was
scrolled.

The Vscrlist plug-in had not fired the event.

This commit closes issue #76.