### PR TITLE
Add some measures for the autoplay policy of the Audio API

### DIFF
--- a/MZ-700/mz700-emu-base.js
+++ b/MZ-700/mz700-emu-base.js
@@ -53,7 +53,9 @@ MZ700EmuBase.prototype.create = async function(opt) {
         let title = canvas.attr("title");
         let checkSound = () => {
             if(!this.sound.resumed()) {
-                canvas.attr("title", "To enable the sound, click here.");
+                canvas.attr("title",
+                    "The Audio API is suspended by autoplay policy. " +
+                    "To resume the sound, click here or volume controls.");
             } else {
                 canvas.attr("title", title);
             }

--- a/MZ-700/mz700-emu.js
+++ b/MZ-700/mz700-emu.js
@@ -328,7 +328,9 @@ MZ700Js.prototype.KeyInState_create = function() {
 
 MZ700Js.prototype.SoundCtrl_create = function() {
     let mute = false;
-    if(cookies.hasItem("mute")) {
+    if(!this.sound.resumed()) {
+        mute = true;
+    } else if(cookies.hasItem("mute")) {
         mute = (cookies.getItem("mute")=="true");
     }
     let volume = 10;


### PR DESCRIPTION
The sound will be muted initially if the audio context is suspended.
I edit the tooltip message to resume the sound on the screen.