### PR TITLE
Fix the Z80 emulation

### DIFF
--- a/Z80/Z80.js
+++ b/Z80/Z80.js
@@ -1741,7 +1741,7 @@ Z80.prototype.createOpecodeTable = function() {
         cycle:4,
         proc: () => {
             var tmp = getA();
-            setA( getA() );
+            setA( this.regB.getA() );
             this.regB.setA( tmp );
             tmp = reg.getF();
             reg.setF( this.regB.getF() );


### PR DESCRIPTION
The process on the mnemonic of EX AF,AF' was missed.
It did not exchange A and A'.

This commit fix issues #123