### PR TITLE
HOTFIX: 8253 counter number

### DIFF
--- a/MZ-700/mz700.js
+++ b/MZ-700/mz700.js
@@ -28,7 +28,7 @@ const MZ700 = function(opt) {
     this.intel8253.counter(1).initCount(15700, () => {
         this.intel8253.counter(2).count(1);
     });
-    this.intel8253.counter(1).initCount(43200, () => {
+    this.intel8253.counter(2).initCount(43200, () => {
         if(this.INTMSK) {
             this.z80.interrupt();
         }


### PR DESCRIPTION
The emulation stopped after the stack was broken by continuous interrupt.

This fixes the issue #154 