### PR TITLE
Fix the emulation bug

### DIFF
--- a/Z80/register.ts
+++ b/Z80/register.ts
@@ -381,7 +381,7 @@ export default class Z80_Register {
     //  }
     //
     addAccWithCarry(n:number): void {
-        const q = (this.getA() + n + (this.getF()) & Z80_Register.C_FLAG);
+        const q = this.getA() + n + (this.getF() & Z80_Register.C_FLAG);
         this.setF( this.getZSTable(q & 255) | ((q & 256) >> 8) |
             ((this.getA() ^ q ^ n) & Z80_Register.H_FLAG) |
             (((n ^ this.getA() ^ 0x80) & (n ^ q) & 0x80) >> 5) );

--- a/test/Z80-ope-calc8.test.js
+++ b/test/Z80-ope-calc8.test.js
@@ -1,0 +1,44 @@
+const Z80Tester = require('./lib/Z80Tester.js');
+const Z80 = require('../Z80/Z80.js');
+const tester = new Z80Tester();
+const cpu = new Z80();
+const chai = require("chai");
+const assert = chai.assert;
+describe("8 bit calculation", ()=>{
+    describe("When C flag is set", ()=>{
+        describe("ADC A,n", ()=>{
+            it("should add extra 1", ()=>{
+                cpu.reg.setA(0x00);
+                cpu.reg.setFlagC();
+                tester.runMnemonics(cpu, [ "ADC A,1" ]);
+                assert.equal(cpu.reg.getA(), 2);
+            });
+        });
+        describe("SBC A,n", ()=>{
+            it("should subtract extra 1", ()=>{
+                cpu.reg.setA(0x02);
+                cpu.reg.setFlagC();
+                tester.runMnemonics(cpu, [ "SBC A,1" ]);
+                assert.equal(cpu.reg.getA(), 0);
+            });
+        });
+    });
+    describe("When C flag is cleared", ()=>{
+        describe("ADC A,n", ()=>{
+            it("should not add extra 1", ()=>{
+                cpu.reg.setA(0x00);
+                cpu.reg.clearFlagC();
+                tester.runMnemonics(cpu, [ "ADC A,1" ]);
+                assert.equal(cpu.reg.getA(), 1);
+            });
+        });
+        describe("SBC A,n", ()=>{
+            it("should not subtract extra 1", ()=>{
+                cpu.reg.setA(0x02);
+                cpu.reg.clearFlagC();
+                tester.runMnemonics(cpu, [ "SBC A,1" ]);
+                assert.equal(cpu.reg.getA(), 1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
The mnemonic `ADC A,n` did not add a value as the carry flag.

This commit fixes the issue #164.