### PR TITLE
Make the UI-codes to simple

### DIFF
--- a/MZ-700/mz700-emu.css
+++ b/MZ-700/mz700-emu.css
@@ -4,12 +4,6 @@
     width:100%;
     height:100%;
 }
-.MZ-700 .screen {
-    border: solid 1px black;
-    background-color: black;
-    padding:0;
-    z-index: -1;
-}
 .MZ-700 button {
     background-color: blue;
     color: white;
@@ -29,12 +23,19 @@
     color: silver;
 }
 
+#mz700screen {
+    border: solid 1px black;
+    background-color: black;
+    padding:0;
+    z-index: -1;
+}
+
 #control-panel
 {
     overflow: auto;
     background-color: white;
 }
-.screen {
+#mz700screen {
     position:fixed;
 }
 
@@ -44,7 +45,7 @@
 }
 
 @media screen and (orientation: portrait) {
-    .screen {
+    #mz700screen {
         position:relative;
     }
     #control-panel
@@ -63,27 +64,6 @@
     background-color: white;
     min-width:690px;
 }
-.MZ-700 .emulation-panel > span.key-switcher {
-    margin:0px;
-    padding:5px;
-    border-style:solid;
-    border-color:blue;
-    border-width:3px;
-    background-color: blue;
-    color: white;
-    font-family: Arial;
-    font-weight: bold;
-}
-.MZ-700 .emulation-panel > span.key-switcher:hover {
-    background-color: white;
-    color: blue;
-}
-.MZ-700 .emulation-panel > span.key-switcher.on,
-.MZ-700 .emulation-panel > span.key-switcher.on:hover {
-    background-color: white;
-    color: blue;
-}
-
 .MZ-700 .data-recorder .cmt-message {
     font-weight: bold;
 }
@@ -106,8 +86,6 @@
     height:30px;
 }
 
-.imm-exec {
-}
 .imm-exec input.address {
     width:60px;
 }
@@ -181,4 +159,21 @@
     padding:0;
     margin:0;
     border-width: 0;
+}
+
+/* Layout */
+.dock.resizer {
+    background-color: white;
+}
+.dock.resizer:hover {
+    background-color: #ccc;
+}
+.dock.resizer.resizing {
+    background-color: blue;
+}
+.dock.horizontal.resizer {
+    cursor: ew-resize;
+}
+.dock.vertical.resizer {
+    cursor: ns-resize;
 }

--- a/MZ-700/pcg700-sample.asm
+++ b/MZ-700/pcg700-sample.asm
@@ -1,0 +1,131 @@
+        ORG     1200H
+        ;===========================================
+        ;
+        ; CHANGE THE CURSOR PATTERN WITH PCG-700
+        ;
+        ;===========================================
+PCGSMPL:ENT
+        CALL    ENPCG       ;ENABLE PCG-700
+        LD      B,00H       ;PCG PAGE 0
+        LD      C,EFH       ;DISPLAY CODE OF CURSOR
+        LD      HL,CGPAT    ;TOP ADDRESS OF PATTERN DATA
+        CALL    SETPCG      ;WRITE PATTERN
+        RST     00H         ;RESET
+        NOP
+        NOP
+        ;===========================================
+        ;
+        ; RESTORE BUILT-IN CURSOR PATTERN
+        ;
+        ;===========================================
+RSTRPCG:ENT
+        CALL    DIPCG       ;ENABLE PCG-700
+        RST     00H         ;RESET
+        ;
+        ;
+        ;
+        ;===========================================
+        ;CURSOR PATTERN DATA
+        ;===========================================
+CGPAT:  ENT
+        DEFB    88H         ;10001000
+        DEFB    D8H         ;11011000
+        DEFB    A8H         ;10101000
+        DEFB    88H         ;10001000
+        DEFB    1FH         ;00011111
+        DEFB    06H         ;00000110
+        DEFB    0CH         ;00001100
+        DEFB    1FH         ;00011111
+        ;
+        ;
+        ;
+        ;===========================================
+        ; ENABLE PCG-700
+        ;===========================================
+ENPCG:  ENT
+        PUSH    HL
+        LD      HL, E012H
+        LD      (HL), 10H
+        POP     HL
+        RET
+        ;
+        ;
+        ;
+        ;===========================================
+        ; DISABLE PCG-700
+        ;===========================================
+DIPCG:  ENT
+        PUSH    HL
+        LD      HL, E012H
+        LD      (HL), 18H
+        POP     HL
+        RET
+        ;
+        ;
+        ;
+        ;===========================================
+        ; SETPCG
+        ;
+        ; B: SELECT CGRAM PAGE 0 or 1
+        ;    0       : PAGE 0
+        ;    NOT 0   : PAGE 1
+        ; C: DISPLAY CODE (80H - FFH)
+        ; HL: TOP ADDRESS OF 8 BYTES CHAR PATTERN
+        ;===========================================
+SETPCG: ENT
+        PUSH    AF
+        PUSH    BC
+        PUSH    DE
+        
+        ;IF B!=0 THEN SEPADR
+        LD      A,B
+        OR      A
+        JR      NZ,SEPADR
+
+        ;OFFSET C FOR PAGE0
+        LD      A,C         
+        SUB     A,80H
+        LD      C,A
+
+SEPADR: ENT
+        ; D: UPPER ADDRESS 00H - 07H
+        ; E: LOWER ADDRESS 00H - FFH
+        LD      D,00H
+        LD      E,C
+        LD      C,03H
+SFTADR: ENT
+        SLA     E
+        RL      D
+        DEC     C
+        JR      NZ,SFTADR
+
+        LD      B,08H       ;TRANSFER LOOP COUNT
+
+        ;
+        ;PATTERN TRANSFER LOOP
+        ;
+WRPAT:  ENT
+
+        LD      A,(HL)      ;LOAD PATTERN
+        PUSH    HL          ;SAVE PATTERN ADDRESS
+        LD      HL,E010H    ;SET PATTERN TO PCG-700
+        LD      (HL),A
+        LD      HL,E011H    ;SET LOWER ADDRESS TO PCG
+        LD      (HL),E
+
+        LD      HL,E012H    ;SET UPPER ADDRESS AND
+        LD      A,10H       ;WRITE PATTERN TO PCG-700
+        OR      D
+        LD      (HL),A      ;WE=1,ADR=D
+        LD      (HL),D      ;WE=0,ADR=D
+
+        POP     HL          ;RESTORE PATTERN ADDRSS
+        INC     HL          ;SRC ADDR
+        INC     E           ;DST ADDR
+        DEC     B           ;LOOP COUNTER
+        JR      NZ,WRPAT    ;UNTIL ZERO
+
+        POP     DE
+        POP     BC
+        POP     AF
+        RET

--- a/emu.html
+++ b/emu.html
@@ -23,29 +23,12 @@
         <link rel="stylesheet" type="text/css" href="./lib/jquery-plugin/jquery.tabview.css"/>
         <link rel="stylesheet" type="text/css" href="./lib/jquery-plugin/jquery.asmlist.css"/>
         <link rel="stylesheet" type="text/css" href="./lib/jquery-plugin/jquery.tool-window.css"/>
-        <link rel="stylesheet" href="./lib/codemirror.css">
+        <link rel="stylesheet" type="text/css" href="./lib/codemirror.css">
 
         <link rel="icon" type="image/png" href="/mz700-js/image/favicon-16x16.png" sizes="16x16"/>
         <link rel="icon" type="image/png" href="/mz700-js/image/favicon-32x32.png" sizes="32x32"/>
         <link rel="icon" type="image/png" href="/mz700-js/image/favicon-48x48.png" sizes="48x48"/>
         <link rel="icon" type="image/png" href="/mz700-js/image/favicon-96x96.png" sizes="96x96"/>
-        <style>
-        .dock.resizer {
-            background-color: white;
-        }
-        .dock.resizer:hover {
-            background-color: #ccc;
-        }
-        .dock.resizer.resizing {
-            background-color: blue;
-        }
-        .dock.horizontal.resizer {
-            cursor: ew-resize;
-        }
-        .dock.vertical.resizer {
-            cursor: ns-resize;
-        }
-        </style>
     </head>
     <body>
         <div id="liquid-panel-MZ-700" class="dock MZ-700">
@@ -54,149 +37,12 @@
                     ><span class="mz700scrn" charSize="8" padding="1" color="0" bgColor="7"
                         >MZ-700 FULL JAVASCRIPT EMULATOR</span></h1>
             </div>
-            <div class="dock MZ-700-body">
-                <div class="screen cmt-slot key-switcher"></div>
+            <div id="mz700container" class="dock">
+                <div id="mz700screen"></div>
             </div>
             <div id="dock-panel-right" class="dock right resizable" style="width:590px;">
-                <div id="wndRegView" class="register-monitor open" title="REGISTER"></div>
-                <div id="wndDumpList" class="memory open" title="MEMORY"></div>
-                <div id="wndImmExec" title="IMM.EXEC."></div>
-                <div id="wndAsmList" class="open" title="Z80 ASM"></div>
             </div>
         </div>
-        <textarea class="default source" style="display:none;">
-        ORG     1200H
-        ;===========================================
-        ;
-        ; CHANGE THE CURSOR PATTERN WITH PCG-700
-        ;
-        ;===========================================
-PCGSMPL:ENT
-        CALL    ENPCG       ;ENABLE PCG-700
-        LD      B,00H       ;PCG PAGE 0
-        LD      C,EFH       ;DISPLAY CODE OF CURSOR
-        LD      HL,CGPAT    ;TOP ADDRESS OF PATTERN DATA
-        CALL    SETPCG      ;WRITE PATTERN
-        RST     00H         ;RESET
-        NOP
-        NOP
-        ;===========================================
-        ;
-        ; RESTORE BUILT-IN CURSOR PATTERN
-        ;
-        ;===========================================
-RSTRPCG:ENT
-        CALL    DIPCG       ;ENABLE PCG-700
-        RST     00H         ;RESET
-        ;
-        ;
-        ;
-        ;===========================================
-        ;CURSOR PATTERN DATA
-        ;===========================================
-CGPAT:  ENT
-        DEFB    88H         ;10001000
-        DEFB    D8H         ;11011000
-        DEFB    A8H         ;10101000
-        DEFB    88H         ;10001000
-        DEFB    1FH         ;00011111
-        DEFB    06H         ;00000110
-        DEFB    0CH         ;00001100
-        DEFB    1FH         ;00011111
-        ;
-        ;
-        ;
-        ;===========================================
-        ; ENABLE PCG-700
-        ;===========================================
-ENPCG:  ENT
-        PUSH    HL
-        LD      HL, E012H
-        LD      (HL), 10H
-        POP     HL
-        RET
-        ;
-        ;
-        ;
-        ;===========================================
-        ; DISABLE PCG-700
-        ;===========================================
-DIPCG:  ENT
-        PUSH    HL
-        LD      HL, E012H
-        LD      (HL), 18H
-        POP     HL
-        RET
-        ;
-        ;
-        ;
-        ;===========================================
-        ; SETPCG
-        ;
-        ; B: SELECT CGRAM PAGE 0 or 1
-        ;    0       : PAGE 0
-        ;    NOT 0   : PAGE 1
-        ; C: DISPLAY CODE (80H - FFH)
-        ; HL: TOP ADDRESS OF 8 BYTES CHAR PATTERN
-        ;===========================================
-SETPCG: ENT
-        PUSH    AF
-        PUSH    BC
-        PUSH    DE
-        
-        ;IF B!=0 THEN SEPADR
-        LD      A,B
-        OR      A
-        JR      NZ,SEPADR
-
-        ;OFFSET C FOR PAGE0
-        LD      A,C         
-        SUB     A,80H
-        LD      C,A
-
-SEPADR: ENT
-        ; D: UPPER ADDRESS 00H - 07H
-        ; E: LOWER ADDRESS 00H - FFH
-        LD      D,00H
-        LD      E,C
-        LD      C,03H
-SFTADR: ENT
-        SLA     E
-        RL      D
-        DEC     C
-        JR      NZ,SFTADR
-
-        LD      B,08H       ;TRANSFER LOOP COUNT
-
-        ;
-        ;PATTERN TRANSFER LOOP
-        ;
-WRPAT:  ENT
-
-        LD      A,(HL)      ;LOAD PATTERN
-        PUSH    HL          ;SAVE PATTERN ADDRESS
-        LD      HL,E010H    ;SET PATTERN TO PCG-700
-        LD      (HL),A
-        LD      HL,E011H    ;SET LOWER ADDRESS TO PCG
-        LD      (HL),E
-
-        LD      HL,E012H    ;SET UPPER ADDRESS AND
-        LD      A,10H       ;WRITE PATTERN TO PCG-700
-        OR      D
-        LD      (HL),A      ;WE=1,ADR=D
-        LD      (HL),D      ;WE=0,ADR=D
-
-        POP     HL          ;RESTORE PATTERN ADDRSS
-        INC     HL          ;SRC ADDR
-        INC     E           ;DST ADDR
-        DEC     B           ;LOOP COUNTER
-        JR      NZ,WRPAT    ;UNTIL ZERO
-
-        POP     DE
-        POP     BC
-        POP     AF
-        RET
-        </textarea>
 
         <!-- jQuery CDN -->
         <script

--- a/lib/jquery-plugin/jquery.mz-control-panel.js
+++ b/lib/jquery-plugin/jquery.mz-control-panel.js
@@ -16,7 +16,6 @@ const NumberUtil = require("../number-util.js");
 function MZControlPanel(element) {
     this._element = element;
     this._mz700jsContainer = $(element);
-    this._mz700ScreenElement = $(element).find(".screen").get(0);
     this._mz700js = null;
 
     this._controlPanel = $("<div/>").attr("id", "control-panel");
@@ -34,8 +33,9 @@ function MZControlPanel(element) {
     this._isRunning = false;
 }
 
-MZControlPanel.prototype.create = async function(mz700js, mzBeep, baseClock) {
+MZControlPanel.prototype.create = async function(mz700js, mz700screen, mzBeep, baseClock) {
     this._mz700js = mz700js;
+    this._mz700screen = mz700screen;
     this._keyboard.mz700keyboard("create", this._mz700js);
     this._emuSpeedControl = $("<span/>").EmuSpeedControl("create", mz700js, baseClock);
     this._emulationPanel
@@ -267,18 +267,18 @@ MZControlPanel.prototype.cancelTimer = function() {
 };
 
 MZControlPanel.prototype.resize = function() {
-    var bboxContainer = new BBox(this._mz700jsContainer.get(0));
-    var bboxScreen = new BBox(this._mz700ScreenElement);
-    var containerSize = bboxContainer.getSize();
+    const bboxContainer = new BBox(this._mz700jsContainer.get(0));
+    const bboxScreen = new BBox(this._mz700screen.get(0));
+    const containerSize = bboxContainer.getSize();
     containerSize._h -= bboxScreen.px("border-top-width");
     containerSize._h -= bboxScreen.px("border-bottom-width");
-    var orgSize = new BBox.Size(320,200);
-    var innerSize = containerSize.getMaxInscribedSize(orgSize);
+    const orgSize = new BBox.Size(320,200);
+    const innerSize = containerSize.getMaxInscribedSize(orgSize);
 
     if(this._controlPanel.is(":visible")) {
-        var phifBBox = new BBox(this._controlPanel.get(0));
-        var phifSize = phifBBox.getSize();
-        var phifMargin = new BBox.Size(
+        const phifBBox = new BBox(this._controlPanel.get(0));
+        const phifSize = phifBBox.getSize();
+        const phifMargin = new BBox.Size(
                 (containerSize._w - phifSize._w) / 2,
                 innerSize._h - phifSize._h);
         if(phifMargin._w < 0) {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "http-server .. -p 3000 -o mz700-js/emu.html",
     "test": "grunt lint && mocha && cd test && sh ./test.sh && cd ..",
     "postinstall": "grunt release",
-    "grunt": "grunt",
-    "build": "grunt",
+    "lint": "grunt lint",
+    "build": "grunt debug",
     "release": "grunt release",
     "generate-docs": "jsdoc --configure jsdoc.json --verbose"
   },


### PR DESCRIPTION
* Create the tool-window widgets on run-time
* Optimize the MZT loading and disassembling
* Move the PCG-700 sample assemble source to a file
* Move the style sheet definitions in HTML to the css file
* Remove unused stuff