### PR TITLE
Create MZ-700 worker synchronously

### DIFF
--- a/MZ-700/mz700-worker.js
+++ b/MZ-700/mz700-worker.js
@@ -9,66 +9,68 @@ const MZ700CanvasRenderer = require('../lib/mz700-canvas-renderer.js');
 const MZ700CG = require("../lib/mz700-cg.js");
 const PCG700 = require("../lib/PCG-700.js");
 const MZMMIO = require("../lib/mz-mmio.js");
-
-const transworker = new TransWorker();
-
-//Create MZ700 and TransWorker.
-transworker.create(new MZ700({
-    onClockFactorUpdate: param => {
-        try {
-            transworker.postNotify("onClockFactorUpdate", param);
-        } catch(ex) {
-            console.error(ex);
-        }
-    },
-    started: () => transworker.postNotify("start"),
-    stopped: () => transworker.postNotify("stop"),
-    notifyClockFreq: tCyclePerSec => transworker.postNotify(
-        "onNotifyClockFreq", [ tCyclePerSec ]),
-    onBreak: () => transworker.postNotify("onBreak"),
-    onUpdateScreen: screenUpdateData => {
-        if(transworker.mz700CanvasRenderer) {
-            for (const addr of Object.keys(screenUpdateData)) {
-                const chr = screenUpdateData[addr];
-                transworker.mz700CanvasRenderer.writeVram(
-                    parseInt(addr), chr.attr, chr.dispcode);
+(async () => {
+    //Create MZ700 and TransWorker.
+    const transworker = new TransWorker();
+    const mz700 = new MZ700();
+    await mz700.create({
+        onClockFactorUpdate: param => {
+            try {
+                transworker.postNotify("onClockFactorUpdate", param);
+            } catch(ex) {
+                console.error(ex);
             }
-        } else {
-            transworker.postNotify( "onUpdateScreen", screenUpdateData);
-        }
-    },
-    onMmioRead: (address, value) => {
-        if(transworker.mz700CanvasRenderer) {
-            transworker.mzMMIO.read(address, value);
-        } else {
-            transworker.postNotify(
-                "onMmioRead", { address: address, value: value });
-        }
-    },
-    onMmioWrite: (address, value) => {
-        if(transworker.mz700CanvasRenderer) {
-            transworker.mzMMIO.write(address, value);
-        } else {
-            transworker.postNotify(
-                "onMmioWrite", { address: address, value: value });
-        }
-    },
-    startSound: freq => transworker.postNotify("startSound", [ freq ]),
-    stopSound: () => transworker.postNotify("stopSound"),
-    onStartDataRecorder: () => transworker.postNotify("onStartDataRecorder"),
-    onStopDataRecorder: () => transworker.postNotify("onStopDataRecorder"),
-}));
-
-//Receive offscreen canvas from the UI-thread
-//and create a renderer and MMIO for PCG-700.
-transworker.listenTransferableObject("offscreenCanvas", offscreenCanvas => {
-    transworker.mz700CanvasRenderer = new MZ700CanvasRenderer();
-    transworker.mz700CanvasRenderer.create({
-        canvas: offscreenCanvas,
-        CG: new MZ700CG(MZ700CG.ROM, 8, 8),
+        },
+        started: () => transworker.postNotify("start"),
+        stopped: () => transworker.postNotify("stop"),
+        notifyClockFreq: tCyclePerSec => transworker.postNotify(
+            "onNotifyClockFreq", [ tCyclePerSec ]),
+        onBreak: () => transworker.postNotify("onBreak"),
+        onUpdateScreen: screenUpdateData => {
+            if(transworker.mz700CanvasRenderer) {
+                for (const addr of Object.keys(screenUpdateData)) {
+                    const chr = screenUpdateData[addr];
+                    transworker.mz700CanvasRenderer.writeVram(
+                        parseInt(addr), chr.attr, chr.dispcode);
+                }
+            } else {
+                transworker.postNotify( "onUpdateScreen", screenUpdateData);
+            }
+        },
+        onMmioRead: (address, value) => {
+            if(transworker.mz700CanvasRenderer) {
+                transworker.mzMMIO.read(address, value);
+            } else {
+                transworker.postNotify(
+                    "onMmioRead", { address: address, value: value });
+            }
+        },
+        onMmioWrite: (address, value) => {
+            if(transworker.mz700CanvasRenderer) {
+                transworker.mzMMIO.write(address, value);
+            } else {
+                transworker.postNotify(
+                    "onMmioWrite", { address: address, value: value });
+            }
+        },
+        startSound: freq => transworker.postNotify("startSound", [ freq ]),
+        stopSound: () => transworker.postNotify("stopSound"),
+        onStartDataRecorder: () => transworker.postNotify("onStartDataRecorder"),
+        onStopDataRecorder: () => transworker.postNotify("onStopDataRecorder"),
     });
-    transworker.mz700CanvasRenderer.setupRendering();
-    transworker.mzMMIO = new MZMMIO();
-    const pcg700 = new PCG700(transworker.mz700CanvasRenderer);
-    pcg700.setupMMIO(transworker.mzMMIO);
-});
+    transworker.create(mz700);
+
+    //Receive offscreen canvas from the UI-thread
+    //and create a renderer and MMIO for PCG-700.
+    transworker.listenTransferableObject("offscreenCanvas", offscreenCanvas => {
+        transworker.mz700CanvasRenderer = new MZ700CanvasRenderer();
+        transworker.mz700CanvasRenderer.create({
+            canvas: offscreenCanvas,
+            CG: new MZ700CG(MZ700CG.ROM, 8, 8),
+        });
+        transworker.mz700CanvasRenderer.setupRendering();
+        transworker.mzMMIO = new MZMMIO();
+        const pcg700 = new PCG700(transworker.mz700CanvasRenderer);
+        pcg700.setupMMIO(transworker.mzMMIO);
+    });
+})();

--- a/MZ-700/mz700.js
+++ b/MZ-700/mz700.js
@@ -11,7 +11,9 @@ const MZ700_Memory    = require("./mz700-memory.js");
 const Z80             = require('../Z80/Z80.js');
 const Z80LineAssembler = require("../Z80/Z80-line-assembler");
 
-const MZ700 = function(opt) {
+function MZ700() { }
+
+MZ700.prototype.create = async function(opt) {
 
     // Screen update buffer
     this._screenUpdateData = {};


### PR DESCRIPTION
The object creating process must be synchronized before adding handlers
to listen transferable objects.