### PR TITLE
Fix MMIO notification

### DIFF
--- a/MZ-700/mz700.js
+++ b/MZ-700/mz700.js
@@ -118,8 +118,10 @@ MZ700.prototype.create = function(opt) {
 
     this.mmio = new MZMMIO();
     for(let address = 0xE000; address < 0xE800; address++) {
-        this.mmio.onRead(address, this.opt.onMmioRead);
-        this.mmio.onWrite(address, this.opt.onMmioWrite);
+        this.mmio.onRead(address,
+            value=>this.opt.onMmioRead(address, value));
+        this.mmio.onWrite(address,
+            value=>this.opt.onMmioWrite(address, value));
     }
 
     //MMIO $E000


### PR DESCRIPTION
The accessed address of MMIO did not have been notified, but
only the value.

It did not affect any functions because any functions was not
implemented on the client side.
But this version is affected.
It implements the PCG700 to the client side.
So the PCG700 did not work.