### PR TITLE
Replace deprecated property 'keyCode' of keyup event to 'code'

### DIFF
--- a/MZ-700/mz700-web-ui.js
+++ b/MZ-700/mz700-web-ui.js
@@ -254,12 +254,12 @@ async function createUI(mz700js, mz700screen, canvas) {
 
     // Operate the emulation state by key
     window.addEventListener("keyup", async event => {
-        switch(event.keyCode) {
-        case 119://F8 - RUN/STOP
+        switch(event.code) {
+        case 0x0042://F8 - RUN/STOP
             event.stopPropagation();
             _isRunning ? mz700js.stop() : mz700js.start();
             break;
-        case 120://F9 - STEP In
+        case 0x0043://F9 - STEP In
             event.stopPropagation();
             _isRunning ? mz700js.stop() : mz700js.step();
             break;


### PR DESCRIPTION
This fix affects the folowing keys scanning:

* `F8` - run
* `F9` - stop or step

This may not work on browsers of X-Window because of its key-code
value may be different. If so, use the mouse click.

This fix would close issue #199.